### PR TITLE
Fixes to Code Climate integration

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,18 @@
+---
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - javascript
+      - python
+  fixme:
+    enabled: true
+  radon:
+    enabled: true
+ratings:
+  paths:
+  - "**.js"
+  - "**.jsx"
+  - "**.py"
+exclude_paths: []

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,4 @@ python:
 addons:
   code_climate:
     repo_token: c711107a821fc3b78db7028995deb601bb43af70473c6349bada5f8fe27bda0a
-before_script: cd src
-script: python manage.py test
+script: python src/manage.py test


### PR DESCRIPTION
Some bugfixes that prevented the `.coverage` file from being sent to Code Climate for coverage analysis.