### PR TITLE
Added coverage reporter command that will run after script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ addons:
   code_climate:
     repo_token: c711107a821fc3b78db7028995deb601bb43af70473c6349bada5f8fe27bda0a
 script: python src/manage.py test
+after_script:
+  - codeclimate-test-reporter


### PR DESCRIPTION
The documentation provided by Code Climate is unclear, as the addition of the key in the add-ons section only ensures that the key is in the environment variables and doesn't run the coverage reporter script.