### PR TITLE
Fix issue related to low coverage test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ python:
 addons:
   code_climate:
     repo_token: c711107a821fc3b78db7028995deb601bb43af70473c6349bada5f8fe27bda0a
-script: python src/manage.py test
+script: coverage run --branch --omit=*test*,*migrations* --source=projects src/manage.py test
 after_script:
   - codeclimate-test-reporter


### PR DESCRIPTION
This is a hotfix for a coverage problem.

**Issue**
- Coverage does not detect Django's loading of model when tests are run through django-nose

**Solution**
- Ensure that coverage.py initialises before the unit tests and Django are run
