### PR TITLE
Disable code coverage on django-nose

### DIFF
--- a/src/projection/settings.py
+++ b/src/projection/settings.py
@@ -125,7 +125,3 @@ STATIC_URL = '/static/'
 # Test Runner Configuration
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
-NOSE_ARGS = [
-    '--with-coverage',
-    '--cover-package=projects',
-]


### PR DESCRIPTION
**Issue**
Implementation of coverage before unittest has lead to another issue: coverage.py is run twice and as such, the first coverage.py does not track the actual code that is being tested.

**Solution**
Removed `--with-coverage` flag from django-nose arguments, effectively disabling coverage.py from running during django-nose tests.