### PR TITLE
Removed trailing spaces in runtime definition

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.2 
+python-3.5.2


### PR DESCRIPTION
Deployment failed in testing. Suspected: trailing spaces in runtime.txt definition file.